### PR TITLE
Fixes some problems

### DIFF
--- a/demo/artist-quarkus/src/main/resources/application.properties
+++ b/demo/artist-quarkus/src/main/resources/application.properties
@@ -3,3 +3,7 @@ quarkus.http.port: 8082
 
 smallrye.graphql.events.enabled: true
 smallrye.graphql.schema.includeScalars: true
+
+
+quarkus.smallrye-graphql.events.enabled=true
+

--- a/federation/quarkus-extension/deployment/src/main/java/com/github/t1/graphql/federation/quarkus/extension/deployment/GraphqlFederationQuarkusExtensionProcessor.java
+++ b/federation/quarkus-extension/deployment/src/main/java/com/github/t1/graphql/federation/quarkus/extension/deployment/GraphqlFederationQuarkusExtensionProcessor.java
@@ -1,12 +1,14 @@
 package com.github.t1.graphql.federation.quarkus.extension.deployment;
 
 import com.github.t1.graphql.federation.quarkus.extension.EntitiesRecorder;
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ApplicationIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
+import io.smallrye.graphql.federation.impl.Federation;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.DotName;
 import org.jboss.logging.Logger;
@@ -19,7 +21,9 @@ class GraphqlFederationQuarkusExtensionProcessor {
     private static final DotName KEY = DotName.createSimple("io.smallrye.graphql.federation.api.Key");
 
     @BuildStep
-    FeatureBuildItem feature() { return new FeatureBuildItem(FEATURE); }
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
 
     @BuildStep
     EntitiesBuildItem findKeyDirectives(ApplicationIndexBuildItem index) {
@@ -35,14 +39,19 @@ class GraphqlFederationQuarkusExtensionProcessor {
     @BuildStep
     @Record(RUNTIME_INIT)
     RouteBuildItem devModeRoute(
-        NonApplicationRootPathBuildItem nonApp,
-        EntitiesBuildItem entitiesBuildItem,
-        EntitiesRecorder entitiesRecorder
+            NonApplicationRootPathBuildItem nonApp,
+            EntitiesBuildItem entitiesBuildItem,
+            EntitiesRecorder entitiesRecorder
     ) {
         return nonApp.routeBuilder()
-            .route(FEATURE)
-            .handler(entitiesRecorder.createHandler(entitiesBuildItem.getEntities()))
-            .displayOnNotFoundPage()
-            .build();
+                .route(FEATURE)
+                .handler(entitiesRecorder.createHandler(entitiesBuildItem.getEntities()))
+                .displayOnNotFoundPage()
+                .build();
+    }
+
+    @BuildStep
+    AdditionalBeanBuildItem beans() {
+        return new AdditionalBeanBuildItem(Federation.class);
     }
 }

--- a/federation/quarkus-extension/runtime/pom.xml
+++ b/federation/quarkus-extension/runtime/pom.xml
@@ -24,6 +24,22 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jsonb</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-graphql-federation-api</artifactId>
+            <version>1.3.2</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-graphql-federation-runtime</artifactId>
+            <version>1.3.2</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-graphql-schema-builder</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/federation/quarkus-extension/runtime/src/main/resources/META-INF/microprofile-config.properties
+++ b/federation/quarkus-extension/runtime/src/main/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,2 @@
+quarkus.smallrye-graphql.events.enabled=true
+smallrye.graphql.events.enabled: true

--- a/federation/quarkus-extension/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/federation/quarkus-extension/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,5 +1,6 @@
 name: GraphQL Federation Quarkus Extension
 description: Allows your GraphQL application to take part in GraphQL Federation by annotating your types with, e.g., `@Key`.
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
 metadata:
   status: "preview"
   keywords:

--- a/pom.xml
+++ b/pom.xml
@@ -23,9 +23,9 @@
 
         <jakartaee.version>8.0.0</jakartaee.version>
         <microprofile-graphql.version>1.1.0</microprofile-graphql.version>
-        <smallrye-graphql.version>1.3.0</smallrye-graphql.version>
+        <smallrye-graphql.version>1.3.2</smallrye-graphql.version>
         <smallrye-context-propagation.version>1.2.1</smallrye-context-propagation.version>
-        <quarkus.version>2.1.0.Final</quarkus.version>
+        <quarkus.version>2.2.3.Final</quarkus.version>
 
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>


### PR DESCRIPTION
Build works again. The cdi event handler is there and calls the federation class.

Unfortunately if you try to run the quarkus services you still get some errors:

Federation#rawServiceSchema fails at building the schema. After the line 143 `builder.clearAdditionalTypes();` the schema breaks (type artist/film not found). If you remove the line it works.

The next error happens in Federation#addMainEntityResolvers. When creating a `new MainEntityResolver` the method MainEntityResolver#toMethod throws a NullPointerException when calling `ScanningContext.getIndex()`.

Maybe somebody knows how to fix those problems.